### PR TITLE
improve(typings): add FlamegraphTooltip interface with proper types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,19 @@
 declare module "d3-flame-graph" {
+    import type { HierarchyRectangularNode } from 'd3-hierarchy';
+
     export function flamegraph(): FlameGraph;
     export interface StackFrame {
         name: string;
         value: number;
         children: StackFrame[];
+        libtype?: string;
+        delta?: number;
+    }
+
+    export interface FlamegraphTooltip<T = unknown> {
+        show(d: HierarchyRectangularNode<T>, node: SVGGElement): void;
+        hide(): void;
+        destroy?(): void;
     }
 
     type LabelHandler = (node: any) => string;
@@ -29,8 +39,8 @@ declare module "d3-flame-graph" {
         minFrameSize(): number;
         title(val: string): FlameGraph;
         title(): string;
-        tooltip(val: boolean): FlameGraph;
-        tooltip(): boolean;
+        tooltip(val: boolean | FlamegraphTooltip): FlameGraph;
+        tooltip(): boolean | FlamegraphTooltip;
         transitionDuration(val: number): FlameGraph;
         transitionDuration(): number;
         transitionEase(val: string): FlameGraph;


### PR DESCRIPTION
## Summary
- Add `FlamegraphTooltip<T>` interface with proper types instead of `any`
- Replace `any` with `HierarchyRectangularNode<T>` from d3-hierarchy for the node parameter
- Replace `any` with `SVGGElement` for the DOM element parameter
- Update `tooltip()` method to accept both `boolean` and `FlamegraphTooltip`
- Add missing optional properties to `StackFrame` (`libtype`, `delta`)