### PR TITLE
Fix: exclude dist folder from linting (fixes #268)

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,6 +3,7 @@ import promise from "eslint-plugin-promise";
 
 export default [
     {
+        ignores: ["src/dist/**"],
         files: ["**/*.js"],
         languageOptions: {
             ecmaVersion: 2022,


### PR DESCRIPTION
Fixes #268

## Summary
- Excluded  from ESLint linting
- The dist folder contains generated build output files that use 2-space indentation (Rollup output)
- The source files in  continue to be linted with 4-space indentation

## Test Plan
- Run 
> d3-flame-graph@4.1.3 lint
> eslint src test - no errors
- Run 
> d3-flame-graph@4.1.3 test
> vitest run


[1m[46m RUN [49m[22m [36mv4.0.18 [39m[90m/Users/mspier/Workspace/d3-flame-graph[39m

 [32m✓[39m test/colorMapper.js [2m([22m[2m43 tests[22m[2m)[22m[32m 3[2mms[22m[39m
 [32m✓[39m test/flamegraph.js [2m([22m[2m10 tests[22m[2m)[22m[32m 26[2mms[22m[39m
 [32m✓[39m test/edgeCases.js [2m([22m[2m37 tests[22m[2m)[22m[32m 33[2mms[22m[39m

[2m Test Files [22m [1m[32m3 passed[39m[22m[90m (3)[39m
[2m      Tests [22m [1m[32m90 passed[39m[22m[90m (90)[39m
[2m   Start at [22m 22:17:24
[2m   Duration [22m 384ms[2m (transform 84ms, setup 0ms, import 172ms, tests 62ms, environment 684ms)[22m - all 90 tests pass